### PR TITLE
Chore: redirect authenticated users to /open

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit'
+
+export async function load({ locals }) {
+  const session = await locals.getSession()
+  if (session) {
+    throw redirect(302, `/open`)
+  }
+  return {}
+}


### PR DESCRIPTION
## Overview

Found myself clicking the `Sign in with GitHub` button every time I come to the site😀

The primary goal is to enhance user experience by redirecting logged-in users directly to the /open route, bypassing unnecessary steps or pages.
